### PR TITLE
chore: mark `hc-launch` as deprecated and suggest `hc-spin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 CLI to run Holochain apps in development mode in tauri windows.
 
+> [!NOTE]
+> This tool is deprecated and no longer available in [Holonix, the Holochain development environment distribution](https://github.com/holochain/holonix). Please use [its replacement `hc-spin`](https://github.com/holochain/hc-spin) instead.
+
 ## License
 
 [![License: CAL 1.0](https://img.shields.io/badge/License-CAL%201.0-blue.svg)](https://github.com/holochain/cryptographic-autonomy-license)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CLI to run Holochain apps in development mode in tauri windows.
 
 [![License: CAL 1.0](https://img.shields.io/badge/License-CAL%201.0-blue.svg)](https://github.com/holochain/cryptographic-autonomy-license)
 
-Copyright (C) 2019 - 2021, Holochain Foundation
+Copyright (C) 2019 - 2025, Holochain Foundation
 
 This program is free software: you can redistribute it and/or modify it under the terms of the license
 provided in the LICENSE file (CAL-1.0). This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
Updated README to indicate deprecation of `hc-launch` tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a deprecation note recommending migration to hc-spin.
  * Updated copyright year to 2025.
  * Expanded the warranty disclaimer to state there is no warranty, including implied merchantability or fitness for a particular purpose.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->